### PR TITLE
fix dynamic appid android

### DIFF
--- a/src/android/IonicDeploy.java
+++ b/src/android/IonicDeploy.java
@@ -342,9 +342,11 @@ public class IonicDeploy extends CordovaPlugin {
   }
 
   private void initApp(String app_id) {
-    SharedPreferences prefs = this.prefs;
+    this.app_id = app_id;
 
+    SharedPreferences prefs = this.prefs;
     prefs.edit().putString("app_id", app_id).apply();
+
     // Used for keeping track of the order versions were downloaded
     int version_count = prefs.getInt("version_count", 0);
     prefs.edit().putInt("version_count", version_count).apply();

--- a/src/android/IonicDeploy.java
+++ b/src/android/IonicDeploy.java
@@ -342,7 +342,7 @@ public class IonicDeploy extends CordovaPlugin {
   private void initApp(String app_id) {
     SharedPreferences prefs = this.prefs;
 
-    prefs.edit().putString("app_id", this.app_id).apply();
+    prefs.edit().putString("app_id", app_id).apply();
     // Used for keeping track of the order versions were downloaded
     int version_count = prefs.getInt("version_count", 0);
     prefs.edit().putInt("version_count", version_count).apply();

--- a/src/android/IonicDeploy.java
+++ b/src/android/IonicDeploy.java
@@ -253,7 +253,9 @@ public class IonicDeploy extends CordovaPlugin {
 
     this.prefs = getPreferences();
 
-    initApp(this.app_id);
+    if(args.length() > 0) {
+      initApp(args.getString(0));
+    }
 
     final SharedPreferences prefs = this.prefs;
 


### PR DESCRIPTION
Most calls of the deploy api take an app_id argument that you must provide to target a specific app. The android code does not use the app_id that is passed from the javascript layer to the javacode. Instead it always picks the app_id stored in the sharedpreferences or the default app_id taken from the strings resource file.

Also the initApp method doesn't store the app_id passed to it as an argument but stores the instance member app_id in the sharedpreferences.

This fix uses the passed app_id if available and makes sure the given appId is stored in the sharedpreferences.