### PR TITLE
Added successful callback calls for initialize and redirect methods

### DIFF
--- a/src/ios/IonicDeploy.m
+++ b/src/ios/IonicDeploy.m
@@ -258,6 +258,8 @@ static NSOperationQueue *delegateQueue;
     if ([jsonRes valueForKey:@"channel"] != nil) {
         self.channel_tag = [jsonRes valueForKey:@"channel"];
     }
+    
+    [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:nil] callbackId:command.callbackId];
 }
 
 - (void) check:(CDVInvokedUrlCommand *)command {
@@ -452,7 +454,7 @@ static NSOperationQueue *delegateQueue;
 }
 
 - (void) redirect:(CDVInvokedUrlCommand *)command {
-    CDVPluginResult* pluginResult = nil;
+    CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:nil];
     if ([self isDebug]) {
         [self showDebugDialog];
     } else {


### PR DESCRIPTION
Hello, thanks for your plugin everything works fine except for one moment

If I understood all correctly right now success callbacks for **init** and **redirect** methods for iOS (didn't tested for android) are not called, I think it's little strange. In this PR I just added calls for these callbacks.