### PR TITLE
Native getPreferences and automatic rollbacks of broken deploys

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -22,6 +22,7 @@
     <preference name="UPDATE_API" default="https://api.ionicjs.com" />
     <preference name="UPDATE_METHOD" default="background" />
     <preference name="MAX_STORE" default="2" />
+    <preference name="ROLLBACK_TIMEOUT" default="10" />
 
     <!-- ios -->
     <platform name="ios">
@@ -55,6 +56,10 @@
             <string>$MAX_STORE</string>
         </config-file>
 
+        <config-file target="*-Info.plist" parent="IonRollbackTimeout">
+            <string>$ROLLBACK_TIMEOUT</string>
+        </config-file>
+
         <header-file src="src/ios/IonicCordovaCommon.h" />
         <source-file src="src/ios/IonicCordovaCommon.m" />
     </platform>
@@ -73,6 +78,7 @@
             <string name="ionic_update_api">$UPDATE_API</string>
             <string name="ionic_update_method">$UPDATE_METHOD</string>
             <string name="ionic_max_versions">$MAX_STORE</string>
+            <string name="ionic_rollback_timeout">$ROLLBACK_TIMEOUT</string>
         </config-file>
 
         <source-file src="src/android/IonicCordovaCommon.java" target-dir="src/com/ionicframework/common" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -76,7 +76,6 @@
         </config-file>
 
         <source-file src="src/android/IonicCordovaCommon.java" target-dir="src/com/ionicframework/common" />
-        <source-file src="src/android/IonicDeploy.java" target-dir="src/com/ionicframework/deploy" />
     </platform>
 
     <dependency id="cordova-plugin-splashscreen" version="^5.0.1"/>

--- a/src/android/IonicCordovaCommon.java
+++ b/src/android/IonicCordovaCommon.java
@@ -77,6 +77,12 @@ public class IonicCordovaCommon extends CordovaPlugin {
     return true;
   }
 
+  /**
+   * Get basic app information.  Used for the Ionic monitoring service.
+   *
+   * @param callbackContext The callback id used when calling back into JavaScript.
+   * @return                True
+   */
   public JSONObject getAppInfo(CallbackContext callbackContext) throws JSONException {
     JSONObject j = new JSONObject();
 
@@ -105,6 +111,12 @@ public class IonicCordovaCommon extends CordovaPlugin {
     return true;
   }
 
+  /**
+   * Get cordova plugin preferences and state information.
+   *
+   * @param callbackContext The callback id used when calling back into JavaScript.
+   * @return                True
+   */
   public JSONObject getPreferences(CallbackContext callbackContext) throws JSONException {
     JSONObject j = new JSONObject();
     int maxV;

--- a/src/android/IonicCordovaCommon.java
+++ b/src/android/IonicCordovaCommon.java
@@ -17,18 +17,8 @@ import android.content.pm.PackageInfo;
 import android.os.Build;
 
 public class IonicCordovaCommon extends CordovaPlugin {
+  public static final String NO_DEPLOY_LABEL = "none";
   public static final String TAG = "IonicCordovaCommon";
-
-  private Context myContext = null;
-  private SharedPreferences prefs = null;
-
-  private String appId;
-  private String debug;
-  private String channel;
-  private String host;
-  private String updateMethod;
-  private int maxVersions;
-  private String currentVersionId;
 
   /**
    * Sets the context of the Command. This can then be used to do things like
@@ -39,28 +29,24 @@ public class IonicCordovaCommon extends CordovaPlugin {
    */
   public void initialize(CordovaInterface cordova, CordovaWebView webView) {
     super.initialize(cordova, webView);
-    this.myContext = this.cordova.getActivity().getApplicationContext();
-    this.prefs = getPreferences();
-
-    this.appId = prefs.getString("app_id", getStringResourceByName("ionic_app_id"));
-    this.channel = prefs.getString("channel", getStringResourceByName("ionic_channel_name"));
-    this.currentVersionId = prefs.getString("uuid", "NO_DEPLOY_AVAILABLE");
-    this.debug = prefs.getString("debug", getStringResourceByName("ionic_debug"));
-    this.host = getStringResourceByName("ionic_update_api");
-    this.updateMethod = getStringResourceByName("ionic_update_method");
-
-    try {
-      this.maxVersions = Integer.parseInt(getStringResourceByName("ionic_max_versions"));
-    } catch(NumberFormatException e) {
-      this.maxVersions = 3;
-    }
   }
 
+  /**
+   * Grabs the shared preferences object for the IonicCordova plugin.
+   * 
+   * @return The SharedPreferences object
+   */
   private SharedPreferences getPreferences() {
-    SharedPreferences prefs = this.myContext.getSharedPreferences("com.ionic.deploy.preferences", Context.MODE_PRIVATE);
-    return prefs;
+    Context cxt = this.cordova.getActivity().getApplicationContext();
+    return cxt.getSharedPreferences("com.ionic.common.preferences", Context.MODE_PRIVATE);
   }
 
+  /**
+   * Grabs a string from the activity's resources.
+   * 
+   * @param aString The name of the resource to retrieve
+   * @return        The string contents of the resource
+   */
   private String getStringResourceByName(String aString) {
     Activity activity = cordova.getActivity();
     String packageName = activity.getPackageName();
@@ -95,10 +81,6 @@ public class IonicCordovaCommon extends CordovaPlugin {
       int versionCode = pInfo.versionCode;
       String platformVersion = String.valueOf(Build.VERSION.RELEASE);
 
-      /*
-      String appName = this.cordova.getActivity().getApplicationInfo().loadLabel(this.cordova.getActivity().getPackageManager());
-      */
-
       j.put("platform", "android");
       j.put("platformVersion", platformVersion);
       j.put("version", versionCode);
@@ -106,36 +88,44 @@ public class IonicCordovaCommon extends CordovaPlugin {
       j.put("bundleVersion", version);
 
       Log.d(TAG, "Got package info. Version: " + version + ", bundleName: " + name + ", versionCode: " + versionCode);
+      final PluginResult result = new PluginResult(PluginResult.Status.OK, j);
+      result.setKeepCallback(false);
+      callbackContext.sendPluginResult(result);
     } catch(Exception ex) {
       Log.e(TAG, "Unable to get package info", ex);
+      callbackContext.error(ex.toString());
     }
 
-    final PluginResult result = new PluginResult(PluginResult.Status.OK, j);
-    result.setKeepCallback(false);
-    callbackContext.sendPluginResult(result);
-
-    return j;
+    return true;
   }
 
   public JSONObject getPreferences(CallbackContext callbackContext) throws JSONException {
     JSONObject j = new JSONObject();
+    int maxV;
 
     try {
-      j.put("appId", appId);
-      j.put("debug", debug);
-      j.put("channel", channel);
-      j.put("host", host);
-      j.put("updateMethod", updateMethod);
-      j.put("maxVersions", maxVersions);
-      j.put("currentVersionId", currentVersionId);
-    } catch(Exception ex) {
-      Log.e(TAG, "Unable to get preferences", ex);
+      maxV = Integer.parseInt(getStringResourceByName("ionic_max_versions"));
+    } catch(NumberFormatException e) {
+      maxV = 2;
     }
 
-    final PluginResult result = new PluginResult(PluginResult.Status.OK, j);
-    result.setKeepCallback(false);
-    callbackContext.sendPluginResult(result);
+    try {
+      j.put("appId", getStringResourceByName("ionic_app_id"));
+      j.put("debug", getStringResourceByName("ionic_debug"));
+      j.put("channel", getStringResourceByName("ionic_channel_name"));
+      j.put("host", getStringResourceByName("ionic_update_api"));
+      j.put("updateMethod", getStringResourceByName("ionic_update_method"));
+      j.put("maxVersions", maxV);
+      j.put("currentVersionId", IonicCordovaCommon.NO_DEPLOY_LABEL);
 
-    return j;
+      final PluginResult result = new PluginResult(PluginResult.Status.OK, j);
+      result.setKeepCallback(false);
+      callbackContext.sendPluginResult(result);
+    } catch(Exception ex) {
+      Log.e(TAG, "Unable to get preferences", ex);
+      callbackContext.error(ex.toString());
+    }
+
+    return true;
   }
 }

--- a/src/android/IonicCordovaCommon.java
+++ b/src/android/IonicCordovaCommon.java
@@ -169,6 +169,11 @@ public class IonicCordovaCommon extends CordovaPlugin {
     }
   }
 
+  /**
+   * Checks if the base version bundled with the app should be loaded, and fires off the load if so.
+   *
+   * @param force Whether to force the load.
+   */
   private void loadInitialVersion(boolean force) {
     Log.d(TAG, "Checking if rollback is needed");
 
@@ -177,6 +182,9 @@ public class IonicCordovaCommon extends CordovaPlugin {
     }
   }
 
+  /**
+   * Loads the version of the app bundled in the binary.
+   */
   private void loadInitialVersion() {
     Log.d(TAG, "LOADING INITIAL VERSION");
     IonicCordovaCommon self = this;

--- a/src/android/IonicCordovaCommon.java
+++ b/src/android/IonicCordovaCommon.java
@@ -9,7 +9,6 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 import org.json.JSONException;
 
-import android.content.SharedPreferences;
 import android.util.Log;
 import android.app.Activity;
 import android.content.Context;
@@ -29,16 +28,6 @@ public class IonicCordovaCommon extends CordovaPlugin {
    */
   public void initialize(CordovaInterface cordova, CordovaWebView webView) {
     super.initialize(cordova, webView);
-  }
-
-  /**
-   * Grabs the shared preferences object for the IonicCordova plugin.
-   * 
-   * @return The SharedPreferences object
-   */
-  private SharedPreferences getPreferences() {
-    Context cxt = this.cordova.getActivity().getApplicationContext();
-    return cxt.getSharedPreferences("com.ionic.common.preferences", Context.MODE_PRIVATE);
   }
 
   /**

--- a/src/android/IonicCordovaCommon.java
+++ b/src/android/IonicCordovaCommon.java
@@ -32,6 +32,16 @@ public class IonicCordovaCommon extends CordovaPlugin {
     super.initialize(cordova, webView);
     this.revertToBase = true;
 
+    // Get the timeout, and default to 10 sec. if you can't.
+    int rollbackTimer;
+
+    try {
+      rollbackTimer = Integer.parseInt(getStringResourceByName("ionic_rollback_timeout"));
+    } catch (NumberFormatException e) {
+      Log.d(TAG, "Couldn't read timeout from config, defaulting to 10 seconds...");
+      rollbackTimer = 10;
+    }
+
     // Make a runnable to check if a rollback is needed
     class DelayedRollback implements Runnable {
       IonicCordovaCommon weak;
@@ -46,7 +56,7 @@ public class IonicCordovaCommon extends CordovaPlugin {
     Handler handler = new Handler();
 
     // Kick off our rollback check after 10 seconds
-    handler.postDelayed(delayed, 10000);
+    handler.postDelayed(delayed, rollbackTimer * 1000);
   }
 
   /**

--- a/src/android/IonicCordovaCommon.java
+++ b/src/android/IonicCordovaCommon.java
@@ -63,15 +63,21 @@ public class IonicCordovaCommon extends CordovaPlugin {
    * @return                  True if the action was valid, false if not.
    */
   public boolean execute(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
-    if(action.equals("getAppInfo")) {
-      this.getAppInfo(args, callbackContext);
-    } else if(action.equals("getPreferences")) {
-      this.getPreferences(callbackContext);
+    switch(action) {
+      case "getAppInfo":
+        this.getAppInfo(callbackContext);
+        break;
+      case "getPreferences":
+        this.getPreferences(callbackContext);
+        break;
+      default:
+        return false;
     }
+
     return true;
   }
 
-  public JSONObject getAppInfo(JSONArray args, CallbackContext callbackContext) throws JSONException {
+  public JSONObject getAppInfo(CallbackContext callbackContext) throws JSONException {
     JSONObject j = new JSONObject();
 
     try {

--- a/src/android/IonicCordovaCommon.java
+++ b/src/android/IonicCordovaCommon.java
@@ -134,6 +134,8 @@ public class IonicCordovaCommon extends CordovaPlugin {
       j.put("host", getStringResourceByName("ionic_update_api"));
       j.put("updateMethod", getStringResourceByName("ionic_update_method"));
       j.put("maxVersions", maxV);
+
+      // Until we update prefs in native-land, the only possible UUID here is 'none'
       j.put("currentVersionId", IonicCordovaCommon.NO_DEPLOY_LABEL);
 
       final PluginResult result = new PluginResult(PluginResult.Status.OK, j);

--- a/src/android/IonicCordovaCommon.java
+++ b/src/android/IonicCordovaCommon.java
@@ -72,6 +72,9 @@ public class IonicCordovaCommon extends CordovaPlugin {
    */
   public boolean execute(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
     switch(action) {
+      case "clearRevertTimer":
+        this.clearRevertTimer(callbackContext);
+        break;
       case "getAppInfo":
         this.getAppInfo(callbackContext);
         break;

--- a/src/android/IonicCordovaCommon.java
+++ b/src/android/IonicCordovaCommon.java
@@ -83,7 +83,7 @@ public class IonicCordovaCommon extends CordovaPlugin {
    * @param callbackContext The callback id used when calling back into JavaScript.
    * @return                True
    */
-  public JSONObject getAppInfo(CallbackContext callbackContext) throws JSONException {
+  public Boolean getAppInfo(CallbackContext callbackContext) throws JSONException {
     JSONObject j = new JSONObject();
 
     try {
@@ -117,7 +117,7 @@ public class IonicCordovaCommon extends CordovaPlugin {
    * @param callbackContext The callback id used when calling back into JavaScript.
    * @return                True
    */
-  public JSONObject getPreferences(CallbackContext callbackContext) throws JSONException {
+  public Boolean getPreferences(CallbackContext callbackContext) throws JSONException {
     JSONObject j = new JSONObject();
     int maxV;
 
@@ -128,7 +128,8 @@ public class IonicCordovaCommon extends CordovaPlugin {
     }
 
     try {
-      j.put("appId", getStringResourceByName("ionic_app_id"));
+      String appId = getStringResourceByName("ionic_app_id");
+      j.put("appId", appId);
       j.put("debug", getStringResourceByName("ionic_debug"));
       j.put("channel", getStringResourceByName("ionic_channel_name"));
       j.put("host", getStringResourceByName("ionic_update_api"));
@@ -138,6 +139,7 @@ public class IonicCordovaCommon extends CordovaPlugin {
       // Until we update prefs in native-land, the only possible UUID here is 'none'
       j.put("currentVersionId", IonicCordovaCommon.NO_DEPLOY_LABEL);
 
+      Log.d(TAG, "Got prefs for AppID: " + appId);
       final PluginResult result = new PluginResult(PluginResult.Status.OK, j);
       result.setKeepCallback(false);
       callbackContext.sendPluginResult(result);

--- a/src/android/IonicCordovaCommon.java
+++ b/src/android/IonicCordovaCommon.java
@@ -170,6 +170,8 @@ public class IonicCordovaCommon extends CordovaPlugin {
   }
 
   private void loadInitialVersion(boolean force) {
+    Log.d(TAG, "Checking if rollback is needed");
+
     if (force || this.revertToBase) {
       this.loadInitialVersion();
     }
@@ -177,5 +179,13 @@ public class IonicCordovaCommon extends CordovaPlugin {
 
   private void loadInitialVersion() {
     Log.d(TAG, "LOADING INITIAL VERSION");
+    IonicCordovaCommon self = this;
+    cordova.getActivity().runOnUiThread(new Runnable() {
+      @Override
+      public void run() {
+        webView.loadUrlIntoView("file:///android_asset/www/index.html", false);
+        webView.clearHistory();
+      }
+    });
   }
 }

--- a/src/ios/IonicCordovaCommon.h
+++ b/src/ios/IonicCordovaCommon.h
@@ -1,9 +1,47 @@
+//
+//  IonicCordovaCommon.h
+//  IonicCordovaCommon
+//
+//  Created by Ionic on 4/26/2018.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
 #import <Cordova/CDVPlugin.h>
 
 @interface IonicCordovaCommon : CDVPlugin
 
+/**
+ * Get basic app information.  Used for the Ionic monitoring service.
+ *
+ * @param command
+ *
+ * The callback id used when calling back into JavaScript.
+ */
 - (void)getAppInfo:(CDVInvokedUrlCommand*)command;
 
-- (void) getPreferences:(CDVInvokedUrlCommand *)command;
+/**
+ * Get cordova plugin preferences and state information.
+ *
+ * @param command
+ *
+ * The callback id used when calling back into JavaScript.
+ */
+- (void)getPreferences:(CDVInvokedUrlCommand *)command;
 
 @end

--- a/src/ios/IonicCordovaCommon.h
+++ b/src/ios/IonicCordovaCommon.h
@@ -27,13 +27,22 @@
 @interface IonicCordovaCommon : CDVPlugin
 
 /**
+ * Cancel the reversion to the bundled version of the app, signaling a successful deploy.
+ *
+ * @param command
+ *
+ * The callback id used when calling back into JavaScript.
+ */
+- (void) clearRevertTimer:(CDVInvokedUrlCommand*)command;
+
+/**
  * Get basic app information.  Used for the Ionic monitoring service.
  *
  * @param command
  *
  * The callback id used when calling back into JavaScript.
  */
-- (void)getAppInfo:(CDVInvokedUrlCommand*)command;
+- (void) getAppInfo:(CDVInvokedUrlCommand*)command;
 
 /**
  * Get cordova plugin preferences and state information.
@@ -42,6 +51,21 @@
  *
  * The callback id used when calling back into JavaScript.
  */
-- (void)getPreferences:(CDVInvokedUrlCommand *)command;
+- (void) getPreferences:(CDVInvokedUrlCommand *)command;
+
+
+/**
+ * Load base version of the app iff the javascript initialize flag isn't cleared.
+ *
+ * @param force
+ *
+ * Whether to force the load regardless of the flag.
+ */
+- (void) loadInitialVersion:(BOOL)force;
+
+/**
+ * Load base version of the app.
+ */
+- (void) loadInitialVersion;
 
 @end

--- a/src/ios/IonicCordovaCommon.m
+++ b/src/ios/IonicCordovaCommon.m
@@ -5,14 +5,14 @@ NSString *const NO_DEPLOY_LABEL = @"none";
 
 @interface IonicCordovaCommon()
 
-@property Boolean revert_to_base;
+@property Boolean revertToBase;
 
 @end
 
 @implementation IonicCordovaCommon
 
 - (void) pluginInitialize {
-    self.revert_to_base = true;
+    self.revertToBase = true;
 
     // Kick off a timer to revert broken updates
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (uint64_t) 10 * NSEC_PER_SEC), dispatch_get_main_queue(), CFBridgingRelease(CFBridgingRetain(^(void) {
@@ -21,7 +21,7 @@ NSString *const NO_DEPLOY_LABEL = @"none";
 }
 
 - (void) clearRevertTimer:(CDVInvokedUrlCommand*)command {
-    self.revert_to_base = false;
+    self.revertToBase = false;
     
     NSLog(@"Cleared revert flag.");
     [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"success"] callbackId:command.callbackId];
@@ -74,7 +74,7 @@ NSString *const NO_DEPLOY_LABEL = @"none";
 }
 
 - (void) loadInitialVersion:(BOOL)force {
-    if (force || self.revert_to_base) {
+    if (force || self.revertToBase) {
         [self loadInitialVersion];
     }
 }

--- a/src/ios/IonicCordovaCommon.m
+++ b/src/ios/IonicCordovaCommon.m
@@ -1,11 +1,13 @@
 #import "IonicCordovaCommon.h"
 #import <Cordova/CDVPluginResult.h>
+#import <objc/message.h>
 
 NSString *const NO_DEPLOY_LABEL = @"none";
 
 @interface IonicCordovaCommon()
 
 @property Boolean revertToBase;
+@property NSString *baseIndexPath;
 
 @end
 
@@ -13,6 +15,7 @@ NSString *const NO_DEPLOY_LABEL = @"none";
 
 - (void) pluginInitialize {
     self.revertToBase = true;
+    self.baseIndexPath = [[NSBundle mainBundle] pathForResource:@"www/index" ofType:@"html"];
 
     // Kick off a timer to revert broken updates
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (uint64_t) 10 * NSEC_PER_SEC), dispatch_get_main_queue(), CFBridgingRelease(CFBridgingRetain(^(void) {
@@ -80,7 +83,13 @@ NSString *const NO_DEPLOY_LABEL = @"none";
 }
 
 - (void) loadInitialVersion {
-    NSLog(@"LOADING BUNDLED VERSION");
+    NSLog(@"Redirecting to bundled index.html");
+    dispatch_async(dispatch_get_main_queue(), ^(void) {
+        NSLog(@"Reloading the web view.");
+        SEL reloadSelector = NSSelectorFromString(@"reload");
+        ((id (*)(id, SEL))objc_msgSend)(self.webView, reloadSelector);
+        [self.webViewEngine loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:self.baseIndexPath]]];
+    });
 }
 
 @end

--- a/src/ios/IonicCordovaCommon.m
+++ b/src/ios/IonicCordovaCommon.m
@@ -18,7 +18,8 @@ NSString *const NO_DEPLOY_LABEL = @"none";
     self.baseIndexPath = [[NSBundle mainBundle] pathForResource:@"www/index" ofType:@"html"];
 
     // Kick off a timer to revert broken updates
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (uint64_t) 10 * NSEC_PER_SEC), dispatch_get_main_queue(), CFBridgingRelease(CFBridgingRetain(^(void) {
+    int rollbackTimeout = [[[NSBundle mainBundle] objectForInfoDictionaryKey:@"IonRollbackTimeout"] intValue];
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (uint64_t) rollbackTimeout * NSEC_PER_SEC), dispatch_get_main_queue(), CFBridgingRelease(CFBridgingRetain(^(void) {
         [self loadInitialVersion:NO];
     })));
 }

--- a/src/ios/IonicCordovaCommon.m
+++ b/src/ios/IonicCordovaCommon.m
@@ -37,7 +37,7 @@ NSString *const NO_DEPLOY_LABEL = @"none";
     NSString *host = [NSString stringWithFormat:@"%@", [[NSBundle mainBundle] objectForInfoDictionaryKey:@"IonApi"]];
     NSString *updateMethod = [NSString stringWithFormat:@"%@", [[NSBundle mainBundle] objectForInfoDictionaryKey:@"IonUpdateMethod"]];
     NSString *channel = [NSString stringWithFormat:@"%@", [[NSBundle mainBundle] objectForInfoDictionaryKey:@"IonChannelName"]];
-    NSString *maxV = [NSString stringWithFormat:@"%@", [[NSBundle mainBundle] valueForKey:@"IonMaxVersions"]];
+    NSString *maxV = [NSString stringWithFormat:@"%@", [[NSBundle mainBundle] objectForInfoDictionaryKey:@"IonMaxVersions"]];
 
     // Build the preferences json object
     NSMutableDictionary *json = [[NSMutableDictionary alloc] init];

--- a/src/ios/IonicCordovaCommon.m
+++ b/src/ios/IonicCordovaCommon.m
@@ -37,7 +37,7 @@ NSString *const NO_DEPLOY_LABEL = @"none";
     NSString *host = [NSString stringWithFormat:@"%@", [[NSBundle mainBundle] objectForInfoDictionaryKey:@"IonApi"]];
     NSString *updateMethod = [NSString stringWithFormat:@"%@", [[NSBundle mainBundle] objectForInfoDictionaryKey:@"IonUpdateMethod"]];
     NSString *channel = [NSString stringWithFormat:@"%@", [[NSBundle mainBundle] objectForInfoDictionaryKey:@"IonChannelName"]];
-    int maxV = [[[NSBundle mainBundle] objectForInfoDictionaryKey:@"IonMaxVersions"] intValue];
+    NSString *maxV = [NSString stringWithFormat:@"%@", [[NSBundle mainBundle] valueForKey:@"IonMaxVersions"]];
 
     // Build the preferences json object
     NSMutableDictionary *json = [[NSMutableDictionary alloc] init];
@@ -46,7 +46,7 @@ NSString *const NO_DEPLOY_LABEL = @"none";
     [json setObject:channel forKey:@"channel"];
     [json setObject:host forKey:@"host"];
     [json setObject:updateMethod forKey:@"updateMethod"];
-    [json setValue:maxV forKey:<#(nonnull NSString *)#> forKey:@"maxVersions"];
+    [json setObject:maxV forKey:@"maxVersions"];
     [json setObject:NO_DEPLOY_LABEL forKey:@"currentVersionId"];
     NSLog(@"Got app preferences: %@", json);
 

--- a/src/ios/IonicCordovaCommon.m
+++ b/src/ios/IonicCordovaCommon.m
@@ -3,6 +3,8 @@
 
 @implementation IonicCordovaCommon
 
+NSString *const NO_DEPLOY_LABEL = @"none";
+
 - (void) getAppInfo:(CDVInvokedUrlCommand*)command
 {
     NSMutableDictionary *json = [[NSMutableDictionary alloc] init];
@@ -29,16 +31,24 @@
 
 - (void) getPreferences:(CDVInvokedUrlCommand*)command
 {
-    NSLog(@"Called getPreferences");
+    // Get preferences
+    NSString *appId = [NSString stringWithFormat:@"%@", [[NSBundle mainBundle] objectForInfoDictionaryKey:@"IonAppId"]];
+    NSString *debug = [NSString stringWithFormat:@"%@", [[NSBundle mainBundle] objectForInfoDictionaryKey:@"IonDebug"]];
+    NSString *host = [NSString stringWithFormat:@"%@", [[NSBundle mainBundle] objectForInfoDictionaryKey:@"IonApi"]];
+    NSString *updateMethod = [NSString stringWithFormat:@"%@", [[NSBundle mainBundle] objectForInfoDictionaryKey:@"IonUpdateMethod"]];
+    NSString *channel = [NSString stringWithFormat:@"%@", [[NSBundle mainBundle] objectForInfoDictionaryKey:@"IonChannelName"]];
+    int maxV = [[[NSBundle mainBundle] objectForInfoDictionaryKey:@"IonMaxVersions"] intValue];
+
+    // Build the preferences json object
     NSMutableDictionary *json = [[NSMutableDictionary alloc] init];
-    [json setObject:@"4e6b62ff" forKey:@"appId"];
-    [json setObject:@"false" forKey:@"debug"];
-    [json setObject:@"Master" forKey:@"channel"];
-    [json setObject:@"https://api-staging.ionicjs.com" forKey:@"host"];
-    [json setObject:@"auto" forKey:@"updateMethod"];
-    [json setObject:@5 forKey:@"maxVersions"];
-    [json setObject:@"2622e7d7-9d39-496c-ad95-87f76b31f10f" forKey:@"currentVersionId"];
-    NSLog(@"Json: %@", json);
+    [json setObject:appId forKey:@"appId"];
+    [json setObject:debug forKey:@"debug"];
+    [json setObject:channel forKey:@"channel"];
+    [json setObject:host forKey:@"host"];
+    [json setObject:updateMethod forKey:@"updateMethod"];
+    [json setValue:maxV forKey:<#(nonnull NSString *)#> forKey:@"maxVersions"];
+    [json setObject:NO_DEPLOY_LABEL forKey:@"currentVersionId"];
+    NSLog(@"Got app preferences: %@", json);
 
     [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:json] callbackId:command.callbackId];
 }

--- a/www/common.ts
+++ b/www/common.ts
@@ -817,4 +817,5 @@ class IonicCordova implements IPluginBaseAPI {
 }
 
 const instance = new IonicCordova();
+cordova.exec(() => {}, console.error, 'IonicCordovaCommon', 'clearRevertTimer');
 export = instance;


### PR DESCRIPTION
Implements native functionality for `getPreferences` as well as adds an automatic rollback in the case of a deploy that breaks javascript.

Todos:

- [x] Android `getPreferences`
- [x] iOS `getPreferences`
- [x] Android rollback API
- [x] iOS rollback API
- [x] Android automated rollbacks
- [x] iOS automated rollbacks