### PR TITLE
Update README to use alpha 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Supported platforms: iOS, Android
 ## Setup
 
 ```bash
-cordova plugin add cordova-plugin-ionic@5.0.0-alpha.1 --save --variable APP_ID="abcd1234" --variable CHANNEL_NAME="Master" --variable UPDATE_METHOD="background"
+cordova plugin add cordova-plugin-ionic@5.0.0-alpha.2 --save --variable APP_ID="abcd1234" --variable CHANNEL_NAME="Master" --variable UPDATE_METHOD="background"
 ```
 
 The plugin will be available on `window` as `IonicCordova`


### PR DESCRIPTION
alpha 1 doesn't work and alpha 2 was released yesterday, so change the example command to install alpha 2