### PR TITLE
Minor API updates & disable if fetch not available.

### DIFF
--- a/types/IonicCordova.d.ts
+++ b/types/IonicCordova.d.ts
@@ -55,15 +55,15 @@ interface IDeployPluginAPI {
    *
    * @param syncOptions (Optional) Application update overrides.
    */
-  sync(syncOptions: ISyncOptions): Promise<ISnapshotInfo>;
+  sync(syncOptions: ISyncOptions): Promise<ISnapshotInfo | undefined>;
 
   /**
    *
-   * @description Get info about the currently deployed update.
+   * @description Get info about the currently deployed update or undefined if none are applied.
    *
    * @since v5.0.0
    */
-  getCurrentVersion(): Promise<ISnapshotInfo>;
+  getCurrentVersion(): Promise<ISnapshotInfo | undefined>;
 
   /**
    * @description Get a list of the snapshots available on the device.
@@ -77,7 +77,7 @@ interface IDeployPluginAPI {
    *
    * @param version The versionId
    */
-  deleteVersionById(versionId: string): Promise<string>;
+  deleteVersionById(versionId: string): Promise<boolean>;
 }
 
 /**

--- a/www/common.ts
+++ b/www/common.ts
@@ -439,12 +439,12 @@ class IonicDeployImpl {
     });
   }
 
-  async getCurrentVersion(): Promise<ISnapshotInfo> {
+  async getCurrentVersion(): Promise<ISnapshotInfo | undefined> {
     const versionId = this._savedPreferences.currentVersionId;
     if (typeof versionId === 'string') {
       return this.getVersionById(versionId);
     }
-    throw new Error('No current version applied.');
+    return;
   }
 
   async getVersionById(versionId: string): Promise<ISnapshotInfo> {
@@ -469,7 +469,7 @@ class IonicDeployImpl {
     return Object.keys(this._savedPreferences.updates).map(k => this._convertToSnapshotInfo(this._savedPreferences.updates[k]));
   }
 
-  async deleteVersionById(versionId: string): Promise<string> {
+  async deleteVersionById(versionId: string): Promise<boolean> {
     const prefs = this._savedPreferences;
 
     if (prefs.currentVersionId === versionId) {
@@ -495,7 +495,7 @@ class IonicDeployImpl {
     // cleanup file cache
     await this.cleanupCache();
 
-    return 'true';
+    return true;
   }
 
   private async cleanupCache() {
@@ -537,7 +537,7 @@ class IonicDeployImpl {
     }
   }
 
-  async sync(syncOptions: ISyncOptions = {}): Promise<ISnapshotInfo> {
+  async sync(syncOptions: ISyncOptions = {}): Promise<ISnapshotInfo | undefined> {
     const prefs = this._savedPreferences;
 
     // TODO: Get API override if present?
@@ -557,13 +557,16 @@ class IonicDeployImpl {
       }
     }
 
-    return {
-      deploy_uuid: prefs.currentVersionId || this.NO_VERSION_DEPLOYED,
-      versionId: prefs.currentVersionId || this.NO_VERSION_DEPLOYED,
-      channel: prefs.channel,
-      binary_version: prefs.binaryVersion || this.UNKNOWN_BINARY_VERSION,
-      binaryVersion: prefs.binaryVersion || this.UNKNOWN_BINARY_VERSION
-    };
+    if (prefs.currentVersionId) {
+      return {
+        deploy_uuid: prefs.currentVersionId || this.NO_VERSION_DEPLOYED,
+        versionId: prefs.currentVersionId || this.NO_VERSION_DEPLOYED,
+        channel: prefs.channel,
+        binary_version: prefs.binaryVersion || this.UNKNOWN_BINARY_VERSION,
+        binaryVersion: prefs.binaryVersion || this.UNKNOWN_BINARY_VERSION
+      };
+    }
+    return;
   }
 }
 
@@ -756,7 +759,7 @@ class IonicDeploy implements IDeployPluginAPI {
     return (await this.delegate).configure(config);
   }
 
-  async deleteVersionById(version: string): Promise<string> {
+  async deleteVersionById(version: string): Promise<boolean> {
     return (await this.delegate).deleteVersionById(version);
   }
 
@@ -772,7 +775,7 @@ class IonicDeploy implements IDeployPluginAPI {
     return (await this.delegate).getAvailableVersions();
   }
 
-  async getCurrentVersion(): Promise<ISnapshotInfo> {
+  async getCurrentVersion(): Promise<ISnapshotInfo | undefined> {
     return (await this.delegate).getCurrentVersion();
   }
 
@@ -784,7 +787,7 @@ class IonicDeploy implements IDeployPluginAPI {
     return (await this.delegate).reloadApp();
   }
 
-  async sync(syncOptions: ISyncOptions = {}): Promise<ISnapshotInfo> {
+  async sync(syncOptions: ISyncOptions = {}): Promise<ISnapshotInfo | undefined> {
     return (await this.delegate).sync();
   }
 }

--- a/www/common.ts
+++ b/www/common.ts
@@ -60,8 +60,6 @@ class IonicDeployImpl {
   public SNAPSHOT_CACHE = 'ionic_built_snapshots';
   // TODO: It would be nice to have this update automagically when we do a version bump
   public PLUGIN_VERSION = '5.0.0';
-  public NO_VERSION_DEPLOYED = 'none';
-  public UNKNOWN_BINARY_VERSION = 'unknown';
 
   constructor(appInfo: IAppInfo, preferences: ISavedPreferences) {
     this.appInfo = appInfo;
@@ -559,11 +557,11 @@ class IonicDeployImpl {
 
     if (prefs.currentVersionId) {
       return {
-        deploy_uuid: prefs.currentVersionId || this.NO_VERSION_DEPLOYED,
-        versionId: prefs.currentVersionId || this.NO_VERSION_DEPLOYED,
+        deploy_uuid: prefs.currentVersionId,
+        versionId: prefs.currentVersionId,
         channel: prefs.channel,
-        binary_version: prefs.binaryVersion || this.UNKNOWN_BINARY_VERSION,
-        binaryVersion: prefs.binaryVersion || this.UNKNOWN_BINARY_VERSION
+        binary_version: prefs.binaryVersion,
+        binaryVersion: prefs.binaryVersion
       };
     }
     return;
@@ -711,7 +709,7 @@ class IonicDeploy implements IDeployPluginAPI {
   constructor(parent: IPluginBaseAPI) {
     this.parent = parent;
     this.delegate = this.initialize();
-    this.fetchIsAvailable = !!fetch;
+    this.fetchIsAvailable = typeof(fetch) === 'function';
     document.addEventListener('deviceready', this.onLoad.bind(this));
   }
 

--- a/www/definitions.ts
+++ b/www/definitions.ts
@@ -10,7 +10,7 @@ export interface IAvailableUpdate {
 
 export interface ISavedPreferences {
   appId: string;
-  binaryVersion?: string;
+  binaryVersion: string;
   debug: string;
   host: string;
   channel: string;


### PR DESCRIPTION
This is my proposed MR to squeeze in a couple last second API tweaks and to make sure the plugin doesn't break the app if `fetch` isn't available.