### PR TITLE
Initial manifest support

### DIFF
--- a/create-local-app.sh
+++ b/create-local-app.sh
@@ -8,6 +8,7 @@ APP_NAME=${IONIC_APP_NAME:-testapp}
 CHANNEL=${IONIC_CHANNEL:-Master}
 CI=1
 UPDATE_METHOD=${IONIC_UPDATE_METHOD:-auto}
+BACKGROUND_DURATION=${IONIC_BACKGROUND_DURATION:-1}
 
 # Build the plugin ts
 npm run build
@@ -21,6 +22,11 @@ npm run build
 # Add cordova platform and install the plugin
 cordova platform add ios@latest
 cordova platform add android@latest
-cordova plugin add ../cordova-plugin-ionic --save --variable APP_ID="${APP_ID}" --variable CHANNEL_NAME="${CHANNEL}" --variable UPDATE_METHOD="${UPDATE_METHOD}" --variable WARN_DEBUG="false" --link
+cordova plugin add ../cordova-plugin-ionic --save \
+--variable MIN_BACKGROUND_DURATION="$BACKGROUND_DURATION" \
+--variable APP_ID="${APP_ID}" \
+--variable CHANNEL_NAME="${CHANNEL}" \
+--variable UPDATE_METHOD="${UPDATE_METHOD}" \
+--variable WARN_DEBUG="false" --link
 cordova prepare ios
 cordova prepare android

--- a/hooks/beforeBuild.js
+++ b/hooks/beforeBuild.js
@@ -9,7 +9,6 @@ module.exports = function(ctx) {
 };
 
 function ionicVersionOutput(rootDir, err, version, stderr) {
-  console.log(rootDir, err, version, stderr);
   if(err) {
     console.error('There was an error checking your version of the Ionic CLI are you sure you have it installed?');
     console.log(err);
@@ -18,7 +17,7 @@ function ionicVersionOutput(rootDir, err, version, stderr) {
   }
   const versionInfo = version.split('.');
   let majorVersion = undefined;
-  while (versionInfo.length > 1 && isNaN(majorVersion)) {
+  while (versionInfo.length && isNaN(majorVersion)) {
     majorVersion = versionInfo.shift();
   }
   if (isNaN(majorVersion)) {
@@ -41,8 +40,6 @@ function ionicVersionOutput(rootDir, err, version, stderr) {
 function ionicManifestOutput(err, version, stderr) {
   if(err) {
     console.error('There was an error generating the intial manifest of files for the deploy plugin.');
-    console.log(err);
-    console.log(stderr);
     process.exit(-1);
   }
   console.log('Ionic Deploy initial manifest successfully generated.');

--- a/hooks/beforeBuild.js
+++ b/hooks/beforeBuild.js
@@ -1,0 +1,49 @@
+const exec = require('child_process').exec;
+
+module.exports = function(ctx) {
+  exec(
+    'ionic --version --no-interactive',
+    { cwd: ctx.opts.projectRoot },
+    ionicVersionOutput.bind({}, ctx.opts.projectRoot)
+  )
+};
+
+function ionicVersionOutput(rootDir, err, version, stderr) {
+  console.log(rootDir, err, version, stderr);
+  if(err) {
+    console.error('There was an error checking your version of the Ionic CLI are you sure you have it installed?');
+    console.log(err);
+    console.log(stderr);
+    process.exit(-1);
+  }
+  const versionInfo = version.split('.');
+  let majorVersion = undefined;
+  while (versionInfo.length > 1 && isNaN(majorVersion)) {
+    majorVersion = versionInfo.shift();
+  }
+  if (isNaN(majorVersion)) {
+    console.error('There was an error checking your version of the Ionic CLI are you sure you have it installed?');
+    process.exit(-1);
+  }
+  else if (majorVersion < 4) {
+    console.error(`You are running version ${majorVersion} of the Ionic CLI. Version 4 or greater is required for this plugin.`);
+    process.exit(-1);
+  }
+
+  console.log('Generating intial manifest for Ionic Deploy...');
+  exec(
+    'ionic deploy manifest --no-interactive',
+    { cwd: rootDir },
+    ionicManifestOutput
+  )
+}
+
+function ionicManifestOutput(err, version, stderr) {
+  if(err) {
+    console.error('There was an error generating the intial manifest of files for the deploy plugin.');
+    console.log(err);
+    console.log(stderr);
+    process.exit(-1);
+  }
+  console.log('Ionic Deploy initial manifest successfully generated.');
+}

--- a/plugin.xml
+++ b/plugin.xml
@@ -21,6 +21,7 @@
     <preference name="UPDATE_METHOD" default="background"/>
     <preference name="MAX_STORE" default="2"/>
     <preference name="MIN_BACKGROUND_DURATION" default="30"/>
+    <hook type="before_build" src="hooks/beforeBuild.js" />
 
     <!-- ios -->
     <platform name="ios">

--- a/www/common.ts
+++ b/www/common.ts
@@ -61,6 +61,7 @@ class IonicDeployImpl {
   public CORDOVA_CACHE = 'ionic_cordova_cache';
   public PLUGIN_VERSION = '5.0.11-0';
   private BUNDLE_VERSION_ID = 'bundled-version';
+  private MANIFEST_FILE = 'pro-manifest.json';
 
   constructor(appInfo: IAppInfo, preferences: ISavedPreferences) {
     this.appInfo = appInfo;
@@ -116,8 +117,16 @@ class IonicDeployImpl {
     return path.join(cordova.file.dataDirectory, this.MANIFEST_CACHE);
   }
 
+  getCordovaCacheDir(): string {
+    return path.join(cordova.file.dataDirectory, this.CORDOVA_CACHE);
+  }
+
   getSnapshotCacheDir(versionId: string): string {
     return path.join(cordova.file.dataDirectory, this.SNAPSHOT_CACHE, versionId);
+  }
+
+  getBundledAppDir(): string {
+    return path.join(cordova.file.applicationDirectory, 'www');
   }
 
   private async _syncPrefs(prefs: ISavedPreferences) {
@@ -205,25 +214,62 @@ class IonicDeployImpl {
     throw new Error(`Error Status ${resp.status}: ${jsonResp ? jsonResp.error.message : await resp.text()}`);
   }
 
-  private async _prepopulateCache() {
+  private async _prepopulateFileCache() {
     // Verify that we've added the bundled files to the cache if possible (bundle has pro-manifest.json)
     // and that it's built from the correct binary
     const prefs = this._savedPreferences;
     let bundledVersionInfo: IAvailableUpdate | undefined = this._savedPreferences.updates[this.BUNDLE_VERSION_ID];
 
+    // if the cache was built from an previous binary we need to update it by deleting from valid updates (cache will get cleaned later)
     if (bundledVersionInfo && bundledVersionInfo.binaryVersion !== prefs.binaryVersion) {
-      // if the cache was built from an previous binary we need to update it
       delete this._savedPreferences.updates[this.BUNDLE_VERSION_ID];
+      try {
+        await this._fileManager.removeFile(this.getManifestCacheDir(), this._getManifestName(this.BUNDLE_VERSION_ID));
+      } catch (e) {
+        console.info('No bundled manifest in cache present to delete.');
+      }
       bundledVersionInfo = undefined;
     }
 
     if (!bundledVersionInfo) {
       try {
-        const bundledManifest = await this.readManifest(this.BUNDLE_VERSION_ID, true);
-        console.log(bundledManifest);
+        // copy the bundled manifest to the manifest cache dir
+        await this._fileManager.copyTo(
+          this.getBundledAppDir(),
+          this.MANIFEST_FILE,
+          this.getManifestCacheDir(),
+          this._getManifestName(this.BUNDLE_VERSION_ID)
+        );
       } catch (e) {
         console.warn('Could not find bundled manifest. Local cache will not be pre-populated.');
+        return;
       }
+      // read the manifest
+      const bundledManifest = await this.readManifest(this.BUNDLE_VERSION_ID);
+      // populate the cache with files from manifest
+      for (const file of bundledManifest) {
+        const relativePathParts = file.href.split('/');
+        const fileName = relativePathParts.pop();
+        const fullPath = path.join(this.getBundledAppDir(), ...relativePathParts);
+        // if file isn't in the cache put it there.
+        const fileAlreadyExists = await this._fileManager.fileExists(this.getFileCacheDir(), this._cleanHash(file.integrity));
+        if (fileName && !fileAlreadyExists) {
+          try {
+            await this._fileManager.copyTo(fullPath, fileName, this.getFileCacheDir(), this._cleanHash(file.integrity));
+          } catch (e) {
+            console.warn(`Failed to copy ${fileName} from bundled app to cache.`);
+          }
+        }
+      }
+      this._savedPreferences.updates[this.BUNDLE_VERSION_ID] = {
+        binaryVersion: prefs.binaryVersion,
+        channel: prefs.channel,
+        lastUsed: new Date().toISOString(),
+        state: UpdateState.Ready,
+        url: 'bundled',
+        versionId: this.BUNDLE_VERSION_ID
+      };
+      this._savePrefs(this._savedPreferences);
     }
 
     return;
@@ -232,7 +278,7 @@ class IonicDeployImpl {
   async downloadUpdate(progress?: CallbackFunction<number>): Promise<boolean> {
     const prefs = this._savedPreferences;
     if (prefs.availableUpdate && prefs.availableUpdate.state === UpdateState.Available) {
-      await this._prepopulateCache();
+      await this._prepopulateFileCache();
       const { manifestBlob, fileBaseUrl } = await this._fetchManifest(prefs.availableUpdate.url);
       const manifestString = await this._fileManager.getFile(
         this.getManifestCacheDir(),
@@ -381,10 +427,9 @@ class IonicDeployImpl {
     });
   }
 
-  private async readManifest(versionId: string, readFromBundle = false): Promise<ManifestFileEntry[]> {
-    const directory = readFromBundle ? `${cordova.file.applicationDirectory}/www` : this.getManifestCacheDir();
+  private async readManifest(versionId: string): Promise<ManifestFileEntry[]> {
     const manifestString = await this._fileManager.getFile(
-      directory,
+      this.getManifestCacheDir(),
       this._getManifestName(versionId)
     );
     return JSON.parse(manifestString);
@@ -452,7 +497,6 @@ class IonicDeployImpl {
 
   private async _isRunningVersion(versionId: string) {
     const currentPath = await this._getServerBasePath();
-    console.log(`fetched current base path as ${currentPath}`);
     return currentPath.includes(versionId);
   }
 
@@ -470,7 +514,6 @@ class IonicDeployImpl {
     const snapshotDir = this.getSnapshotCacheDir(versionId);
     try {
       const dirEntry = await this._fileManager.getDirectory(snapshotDir, false);
-      console.log(`directory found for snapshot ${versionId} deleting`);
       await (new Promise( (resolve, reject) => dirEntry.removeRecursively(resolve, reject)));
     } catch (e) {
       console.log('No directory found for snapshot no need to delete');
@@ -478,9 +521,19 @@ class IonicDeployImpl {
   }
 
   private async _copyBaseAppDir(versionId: string) {
+    const hasBundledManifest = this._fileManager.fileExists(this.getBundledAppDir(), this.MANIFEST_FILE);
+    if (hasBundledManifest) {
+      try {
+        return this._copyCordovaFiles(versionId);
+      } catch (e) {
+        console.warn('Error copying only bundled cordova files. Attempting to copy entire bundle instead.');
+      }
+    }
+
+    console.warn('Copying all bundled files to new version for base.');
     return new Promise( async (resolve, reject) => {
       try {
-        const rootAppDirEntry = await this._fileManager.getDirectory(`${cordova.file.applicationDirectory}/www`, false);
+        const rootAppDirEntry = await this._fileManager.getDirectory(this.getBundledAppDir(), false);
         const snapshotCacheDirEntry = await this._fileManager.getDirectory(this.getSnapshotCacheDir(''), true);
         rootAppDirEntry.copyTo(snapshotCacheDirEntry, versionId, resolve, reject);
       } catch (e) {
@@ -488,6 +541,36 @@ class IonicDeployImpl {
       }
     });
   }
+
+  private async _copyCordovaFiles(versionId: string) {
+    // use bundled manifest to copy over only files not included in the manifest which should be cordova specific files
+    const bundledManifest = await this.readManifest(this.BUNDLE_VERSION_ID);
+
+    // get the top level dir & file names from manifest
+    const bundledEntryNames = new Set<string>();
+    // add the pro-manifest.json off the bat
+    bundledEntryNames.add(this.MANIFEST_FILE);
+    for (const file of bundledManifest) {
+      const pathParts = file.href.split('/');
+      const topLevelName = pathParts.shift();
+      if (topLevelName) {
+        bundledEntryNames.add(topLevelName);
+      }
+    }
+
+    const bundleDirEntry = await this._fileManager.getDirectory(this.getBundledAppDir(), false);
+    const reader = bundleDirEntry.createReader();
+    const entries = await new Promise<Entry[]>((resolve, reject) => reader.readEntries(resolve, reject));
+    for (const entry of entries) {
+      // if it's in the manifest we don't need it.
+      if (bundledEntryNames.has(entry.name)) {
+        continue;
+      }
+      const snapshotCacheDirEntry = await this._fileManager.getDirectory(this.getSnapshotCacheDir(versionId), true);
+      await new Promise((resolve, reject) => entry.copyTo(snapshotCacheDirEntry, entry.name, resolve, reject));
+    }
+  }
+
 
   private async _copyManifestFiles(versionId: string, progress?: CallbackFunction<number>) {
     const snapshotDir = this.getSnapshotCacheDir(versionId);
@@ -570,7 +653,6 @@ class IonicDeployImpl {
     // delete snapshot directory
     const snapshotDir = this.getSnapshotCacheDir(versionId);
     const dirEntry = await this._fileManager.getDirectory(snapshotDir, false);
-    console.log(`directory found for snapshot ${versionId} deleting`);
     await (new Promise((resolve, reject) => dirEntry.removeRecursively(resolve, reject)));
 
     // delete manifest
@@ -613,7 +695,10 @@ class IonicDeployImpl {
 
     let updates = [];
     for (const versionId of Object.keys(prefs.updates)) {
-      updates.push(prefs.updates[versionId]);
+      // don't clean up the bundled version
+      if (versionId !== this.BUNDLE_VERSION_ID) {
+        updates.push(prefs.updates[versionId]);
+      }
     }
 
     updates = updates.sort((a, b) => a.lastUsed.localeCompare(b.lastUsed));

--- a/www/common.ts
+++ b/www/common.ts
@@ -58,6 +58,7 @@ class IonicDeployImpl {
   public FILE_CACHE = 'ionic_snapshot_files';
   public MANIFEST_CACHE = 'ionic_manifests';
   public SNAPSHOT_CACHE = 'ionic_built_snapshots';
+  public CORDOVA_CACHE = 'ionic_cordova_cache';
   public PLUGIN_VERSION = '5.0.9';
 
   constructor(appInfo: IAppInfo, preferences: ISavedPreferences) {
@@ -196,9 +197,16 @@ class IonicDeployImpl {
     throw new Error(`Error Status ${resp.status}: ${jsonResp ? jsonResp.error.message : await resp.text()}`);
   }
 
+  private async _verifyBundledCache() {
+    // Verify that we've added the bundled files to the cache if possible (bundle has pro-manifest.json)
+    // and that it's built from the correct binary
+    return;
+  }
+
   async downloadUpdate(progress?: CallbackFunction<number>): Promise<boolean> {
     const prefs = this._savedPreferences;
     if (prefs.availableUpdate && prefs.availableUpdate.state === UpdateState.Available) {
+      await this._verifyBundledCache();
       const { manifestBlob, fileBaseUrl } = await this._fetchManifest(prefs.availableUpdate.url);
       const manifestString = await this._fileManager.getFile(
         this.getManifestCacheDir(),

--- a/www/common.ts
+++ b/www/common.ts
@@ -58,7 +58,6 @@ class IonicDeployImpl {
   public FILE_CACHE = 'ionic_snapshot_files';
   public MANIFEST_CACHE = 'ionic_manifests';
   public SNAPSHOT_CACHE = 'ionic_built_snapshots';
-  public CORDOVA_CACHE = 'ionic_cordova_cache';
   public PLUGIN_VERSION = '5.0.11-0';
   private BUNDLE_VERSION_ID = 'bundled-version';
   private MANIFEST_FILE = 'pro-manifest.json';
@@ -115,10 +114,6 @@ class IonicDeployImpl {
 
   getManifestCacheDir(): string {
     return path.join(cordova.file.dataDirectory, this.MANIFEST_CACHE);
-  }
-
-  getCordovaCacheDir(): string {
-    return path.join(cordova.file.dataDirectory, this.CORDOVA_CACHE);
   }
 
   getSnapshotCacheDir(versionId: string): string {


### PR DESCRIPTION
This can provide caching on the first update received by using a hook during the cordova build process to generate a manifest file that gets added into the binary build and then the plugin can use that to pre-populate the file cache on the device.