### PR TITLE
Fix/none update resume error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 ======
 
+## 5.1.6
+
+* Fixed a bug with none update method strategy that could cause background updates upon resume of the app from background
+
 ## 5.0.6
 
 * Fixed a bug with version rebulds that could make some initial redirects take up to 15 seconds.

--- a/www/common.ts
+++ b/www/common.ts
@@ -356,7 +356,7 @@ class IonicDeployImpl {
     const prefs = this._savedPreferences;
     // Is the current version built from a previous binary?
     if (prefs.currentVersionId) {
-      if (!this.isCurrentVersion(prefs.updates[prefs.currentVersionId])) {
+      if (!this.isCurrentVersion(prefs.updates[prefs.currentVersionId]) && !this._isRunningVersion(prefs.currentVersionId)) {
         console.log(
           `Update ${prefs.currentVersionId} was built for different binary version removing update from device` +
           `Update binaryVersionName: ${prefs.updates[prefs.currentVersionId].binaryVersionName}, Device binaryVersionName ${prefs.binaryVersionName}` +
@@ -696,8 +696,7 @@ class IonicDeploy implements IDeployPluginAPI {
 
   async onResume() {
     if (this.fetchIsAvailable && this.lastPause && this.minBackgroundDuration && Date.now() - this.lastPause > this.minBackgroundDuration * 1000) {
-      await (await this.delegate).sync();
-      await this.reloadApp();
+      await (await this.delegate)._handleInitialPreferenceState();
     }
   }
 


### PR DESCRIPTION
This should fix #138 where when using the `UPDATE_METHOD=none` background updates can be applied inadvertently via the `onResume` method using the `sync` function directly.