### PR TITLE
Add ACCESS_NETWORK_STATE permission to make navigator.onLine work

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -69,6 +69,10 @@
             <preference name="DisableDeploy" value="false"/>
         </config-file>
 
+        <config-file target="AndroidManifest.xml" parent="/*">
+            <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+        </config-file>
+
         <config-file target="res/values/strings.xml" parent="/resources">
             <string name="ionic_app_id">$APP_ID</string>
             <string name="ionic_channel_name">$CHANNEL_NAME</string>


### PR DESCRIPTION
navigator.onLine will return always true, even in airplane mode, if the app doesn't have ACCESS_NETWORK_STATE permission.

Closes https://github.com/ionic-team/cordova-plugin-ionic/issues/143