### PR TITLE
Check if the device is online before checking for updates

### DIFF
--- a/www/common.ts
+++ b/www/common.ts
@@ -140,6 +140,10 @@ class IonicDeployImpl {
   }
 
   async checkForUpdate(): Promise<CheckDeviceResponse> {
+    const isOnline = navigator && navigator.onLine;
+    if (!isOnline) {
+      throw new Error('The device is offline.');
+    }
     const prefs = this._savedPreferences;
     const appInfo = this.appInfo;
     const endpoint = `${prefs.host}/apps/${prefs.appId}/channels/check-device`;


### PR DESCRIPTION
and throw and error if it is offline instead of making the API call that will fail anyway because it's offline.