### PR TITLE
Change hook to run before_prepare and make it async

### DIFF
--- a/hooks/beforePrepare.js
+++ b/hooks/beforePrepare.js
@@ -1,19 +1,21 @@
 const exec = require('child_process').exec;
 
 module.exports = function(ctx) {
-  exec(
-    'ionic --version --no-interactive',
-    { cwd: ctx.opts.projectRoot },
-    ionicVersionOutput.bind({}, ctx.opts.projectRoot)
-  )
+  return new Promise((resolve, reject) => {
+    exec(
+      'ionic --version --no-interactive',
+      { cwd: ctx.opts.projectRoot },
+      ionicVersionOutput.bind({}, ctx.opts.projectRoot, resolve, reject)
+    )
+  });
 };
 
-function ionicVersionOutput(rootDir, err, version, stderr) {
+function ionicVersionOutput(rootDir, resolve, reject, err, version, stderr) {
   if(err) {
     console.error('There was an error checking your version of the Ionic CLI are you sure you have it installed?');
     console.log(err);
     console.log(stderr);
-    process.exit(-1);
+    reject();
   }
   const versionInfo = version.split('.');
   let majorVersion = undefined;
@@ -22,25 +24,26 @@ function ionicVersionOutput(rootDir, err, version, stderr) {
   }
   if (isNaN(majorVersion)) {
     console.error('There was an error checking your version of the Ionic CLI are you sure you have it installed?');
-    process.exit(-1);
+    reject();
   }
   else if (majorVersion < 4) {
     console.error(`You are running version ${majorVersion} of the Ionic CLI. Version 4 or greater is required for this plugin.`);
-    process.exit(-1);
+    reject();
   }
 
   console.log('Generating intial manifest for Ionic Deploy...');
   exec(
     'ionic deploy manifest --no-interactive',
     { cwd: rootDir },
-    ionicManifestOutput
+    ionicManifestOutput.bind({}, resolve, reject)
   )
 }
 
-function ionicManifestOutput(err, version, stderr) {
+function ionicManifestOutput(resolve, reject, err, version, stderr) {
   if(err) {
     console.error('There was an error generating the intial manifest of files for the deploy plugin.');
-    process.exit(-1);
+    reject()
   }
+  resolve();
   console.log('Ionic Deploy initial manifest successfully generated.');
 }

--- a/plugin.xml
+++ b/plugin.xml
@@ -18,7 +18,7 @@
     <preference name="UPDATE_METHOD" default="background"/>
     <preference name="MAX_STORE" default="2"/>
     <preference name="MIN_BACKGROUND_DURATION" default="30"/>
-    <hook type="before_build" src="hooks/beforeBuild.js"/>
+    <hook type="before_prepare" src="hooks/beforePrepare.js"/>
     <!-- ios -->
     <platform name="ios">
         <config-file target="config.xml" parent="/*">


### PR DESCRIPTION
Make the hook run on before_prepare instead of before_build as some users might not build with the cli or might just use run command, which doesn't trigger before_build, while before_prepare is run in run and in build and in a few more cases.

Also made it async so Cordova doesn't run prepare until the hook finish