### PR TITLE
`ionicManifestOutput` show more info about error

### DIFF
--- a/hooks/beforePrepare.js
+++ b/hooks/beforePrepare.js
@@ -42,6 +42,8 @@ function ionicVersionOutput(rootDir, resolve, reject, err, version, stderr) {
 function ionicManifestOutput(resolve, reject, err, version, stderr) {
   if(err) {
     console.error('There was an error generating the intial manifest of files for the deploy plugin.');
+    console.log(err);
+    console.log(stderr);
     reject()
   }
   resolve();


### PR DESCRIPTION
Just found out it recently, trying to build a project that already has 'manifest.json' accidentally created with incorrect permissions. It was a real pain to find out what's the problem before I've added these two lines locally