### PR TITLE
Get dataDirectory from getAppInfo function

### DIFF
--- a/src/android/IonicCordovaCommon.java
+++ b/src/android/IonicCordovaCommon.java
@@ -4,6 +4,7 @@ import android.app.Dialog;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.graphics.Color;
+import android.net.Uri;
 import android.view.animation.AlphaAnimation;
 import android.view.animation.Animation;
 import android.view.animation.DecelerateInterpolator;
@@ -27,6 +28,7 @@ import android.app.Activity;
 import android.content.pm.PackageInfo;
 import android.os.Build;
 
+import java.io.File;
 import java.util.Iterator;
 import java.util.UUID;
 
@@ -105,6 +107,7 @@ public class IonicCordovaCommon extends CordovaPlugin {
       j.put("bundleVersion", versionName);
       j.put("binaryVersionName", versionName);
       j.put("device", this.uuid);
+      j.put("dataDirectory", toDirUrl(cordova.getActivity().getFilesDir()));
 
       Log.d(TAG, "Got package info. Version: " + versionName + ", bundleName: " + name + ", versionCode: " + versionCode);
       final PluginResult result = new PluginResult(PluginResult.Status.OK, j);
@@ -279,6 +282,10 @@ public class IonicCordovaCommon extends CordovaPlugin {
     final PluginResult result = new PluginResult(PluginResult.Status.OK, newPrefs);
     result.setKeepCallback(false);
     callbackContext.sendPluginResult(result);
+  }
+
+  private static String toDirUrl(File f) {
+    return Uri.fromFile(f).toString() + '/';
   }
 
 }

--- a/src/ios/IonicCordovaCommon.m
+++ b/src/ios/IonicCordovaCommon.m
@@ -32,6 +32,8 @@
     NSString* bundleName = [[NSBundle mainBundle] infoDictionary][@"CFBundleIdentifier"];
     NSString* versionName = [[NSBundle mainBundle] infoDictionary][@"CFBundleShortVersionString"];
     NSString* uuid = [prefs stringForKey:@"uuid"];
+    NSString *libPath = [NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES) objectAtIndex:0];
+    NSString * cordovaDataDirectory = [libPath stringByAppendingPathComponent:@"NoCloud"];
 
     if (versionName == nil) {
       versionName = [[NSBundle mainBundle] infoDictionary][@"CFBundleVersion"];
@@ -48,6 +50,7 @@
     json[@"bundleVersion"] = versionName;
     json[@"binaryVersionName"] = versionName;
     json[@"device"] = uuid;
+    json[@"dataDirectory"] = [[NSURL fileURLWithPath:cordovaDataDirectory] absoluteString];
     NSLog(@"Got app info: %@", json);
 
     [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:json] callbackId:command.callbackId];

--- a/types/IonicCordova.d.ts
+++ b/types/IonicCordova.d.ts
@@ -375,6 +375,11 @@ interface IAppInfo {
    * A generated device ID (NOT a native device ID)
    */
   device: string;
+
+  /**
+   * Directory where the snapshots are stored
+   */
+  dataDirectory: string;
 }
 
 /**

--- a/www/common.ts
+++ b/www/common.ts
@@ -114,7 +114,7 @@ class IonicDeployImpl {
   }
 
   getSnapshotCacheDir(versionId: string): string {
-    return Path.join(cordova.file.dataDirectory, this.SNAPSHOT_CACHE, versionId);
+    return Path.join(this.appInfo.dataDirectory, this.SNAPSHOT_CACHE, versionId);
   }
 
   getBundledAppDir(): string {


### PR DESCRIPTION
As cordova.file.dataDirectory is undefined sometimes, get corresponding native `dataDirectory` from the getAppInfo function

Closes #193 