### PR TITLE
Add cordova-plugin-whitelist dependency

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -79,5 +79,6 @@
     <dependency id="cordova-plugin-ionic-webview" version=">=2.1.4"/>
     <dependency id="cordova-plugin-file" version="^6.0.1"/>
     <dependency id="cordova-plugin-file-transfer" version="^1.7.1"/>
+    <dependency id="cordova-plugin-whitelist" version="^1.3.3"/>
     <author>Ionic</author>
 </plugin>


### PR DESCRIPTION
cordova-plugin-whitelist is installed as default in Cordova apps, but not in Capacitor apps, so cordova-plugin-file-transfer doesn't work in Android without it.

Adding the dependency to install it if missing.