### PR TITLE
threadhelper also for copyTo and remove actions

### DIFF
--- a/src/android/IonicCordovaCommon.java
+++ b/src/android/IonicCordovaCommon.java
@@ -95,9 +95,17 @@ public class IonicCordovaCommon extends CordovaPlugin {
     } else if (action.equals("configure")){
       this.configure(callbackContext, args.getJSONObject(0));
     } else if (action.equals("copyTo")){
-      this.copyTo(callbackContext, args.getJSONObject(0));
+      threadhelper( new FileOp( ){
+        public void run(final JSONArray passedArgs, final CallbackContext cbcontext) throws JSONException {
+          copyTo(callbackContext, args.getJSONObject(0));
+        }
+      }, args, callbackContext);
     } else if (action.equals("remove")){
-      this.remove(callbackContext, args.getJSONObject(0));
+      threadhelper( new FileOp( ){
+        public void run(final JSONArray passedArgs, final CallbackContext cbcontext) throws JSONException {
+          remove(callbackContext, args.getJSONObject(0));
+        }
+      }, args, callbackContext);
     } else if (action.equals("downloadFile")){
       threadhelper( new FileOp( ){
         public void run(final JSONArray passedArgs, final CallbackContext cbcontext) throws JSONException {

--- a/src/android/IonicCordovaCommon.java
+++ b/src/android/IonicCordovaCommon.java
@@ -109,7 +109,7 @@ public class IonicCordovaCommon extends CordovaPlugin {
     } else if (action.equals("downloadFile")){
       threadhelper( new FileOp( ){
         public void run(final JSONArray passedArgs, final CallbackContext cbcontext) throws JSONException {
-          downloadFile(cbcontext, passedArgs.getJSONObject(0));
+          downloadFile(callbackContext, passedArgs.getJSONObject(0));
         }
       }, args, callbackContext);
 


### PR DESCRIPTION
In Android, I experienced that "copyTo" and "remove" can take several seconds (i verified at least 16 secs) to execute, and during the execution the UI is blocked. This is very bad for background and custom update mode.
I set up for them the "threadhelper" (aka cordova.getThreadPool().execute()), just like it was made for "downloadFile", and it works perfectly without blocking the UI.

Maybe there is a way to do it more "globally" for all the action, however now it works really good.