### PR TITLE
chore: Use 3.8.3 typescript version

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,6 @@
     "testRegex": "tests/.*\\.(ts|js)$"
   },
   "dependencies": {
-    "typescript": "^3.5.3"
+    "typescript": "3.8.3"
   }
 }


### PR DESCRIPTION
3.9.0 and newer don't work with the publish scripts because of the version of angular compiler