### PR TITLE
fix(android): Use implementation instead of compile for dependencies

### DIFF
--- a/src/android/cordovapluginionic.gradle
+++ b/src/android/cordovapluginionic.gradle
@@ -3,7 +3,7 @@ repositories{
 }
 
 dependencies {
-   compile 'commons-io:commons-io:2.4'
+   implementation 'commons-io:commons-io:2.4'
 }
 
 android {


### PR DESCRIPTION
compile has been deprecated for a long time and it was removed in gradle plugin 7, so users that upgrade the gradle plugin to 7.0 or newer won't be able to build their apps.