### PR TITLE
chore: Remove whitelist dependency

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -77,6 +77,5 @@
         </js-module>
     </platform>
     <dependency id="cordova-plugin-ionic-webview" version=">=2.1.4"/>
-    <dependency id="cordova-plugin-whitelist" version="^1.3.3"/>
     <author>Ionic</author>
 </plugin>


### PR DESCRIPTION
whitelist plugin was added to make file-transfer work, but it was removed long ago, so it's not needed anymore and will cause problems with cordova-android 10 as the plugin was integrated and old versions will fail to install.