### PR TITLE
fix(ios): error 28 – no space left on device

### DIFF
--- a/src/ios/IonicCordovaCommon.m
+++ b/src/ios/IonicCordovaCommon.m
@@ -90,6 +90,14 @@
             NSLog(@"File is saved to %@", target);
             [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK] callbackId:command.callbackId];
         }
+
+        // When numerous downloads are called the sessions are not always invalidated and cleared by iOS14.
+        // This leads to error 28 – no space left on device so we manually flush and invalidate to free up space
+        if(urlSession != nil) {
+            [urlSession flushWithCompletionHandler:^{
+                [urlSession finishTasksAndInvalidate];
+            }];
+        }
     }] resume];
 }
 


### PR DESCRIPTION
In iOS, the sessions are not always invalidated and cleared by iOS14, this leads to "error 28 – no space left on device", so sessions have to be manually flushed and invalidated.