### PR TITLE
fix error 28 – no space left on device on iOS

### DIFF
--- a/src/ios/IonicCordovaCommon.m
+++ b/src/ios/IonicCordovaCommon.m
@@ -90,6 +90,14 @@
             NSLog(@"File is saved to %@", target);
             [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK] callbackId:command.callbackId];
         }
+
+        // When numerous downloads are called the sessions are not always invalidated and cleared by iOS14.
+        // This leads to error 28 – no space left on device so we manually flush and invalidate to free up space
+        if(urlSession != nil) {
+            [urlSession flushWithCompletionHandler:^{
+                [urlSession finishTasksAndInvalidate];
+            }];
+        }
     }] resume];
 }
 


### PR DESCRIPTION
Accepts this PR from the upstream repo: https://github.com/ionic-team/cordova-plugin-ionic/pull/247