### PR TITLE
fix: remove debug and replace with disabled preference

### DIFF
--- a/docs/interfaces/ideployconfig.md
+++ b/docs/interfaces/ideployconfig.md
@@ -14,7 +14,7 @@ The configuration for the deploy plugin on the device.
 
 * [appId](ideployconfig.md#appid)
 * [channel](ideployconfig.md#channel)
-* [debug](ideployconfig.md#debug)
+* [disabled](ideployconfig.md#disabled)
 * [host](ideployconfig.md#host)
 * [maxVersions](ideployconfig.md#maxversions)
 * [minBackgroundDuration](ideployconfig.md#minbackgroundduration)
@@ -42,13 +42,13 @@ ___
 The [channel](https://ionicframework.com/docs/pro/deploy/channels) that the plugin should listen for updates on.
 
 ___
-<a id="debug"></a>
+<a id="disabled"></a>
 
-### `<Optional>` debug
+### `<Optional>` disabled
 
-**● debug**: *`undefined` \| `true` \| `false`*
+**● disabled**: *`undefined` \| `true` \| `false`*
 
-whether or not the app should in debug mode
+Whether the user disabled deploy updates or not.
 
 ___
 <a id="host"></a>

--- a/www/IonicCordova.ts
+++ b/www/IonicCordova.ts
@@ -154,9 +154,9 @@ export interface IDeployConfig {
   appId?: string;
 
   /**
-   * whether or not the app should in debug mode
+   * Whether the user disabled deploy updates or not.
    */
-  debug?: boolean;
+  disabled?: boolean;
 
   /**
    * @ignore

--- a/www/guards.ts
+++ b/www/guards.ts
@@ -12,7 +12,7 @@ export function isPluginConfig(o: object): o is IDeployConfig {
   return obj &&
     (obj.appId === undefined || typeof obj.appId === 'string') &&
     (obj.channel === undefined || typeof obj.channel === 'string') &&
-    (obj.debug === undefined || typeof obj.debug === 'string') &&
+    (obj.disabled === undefined || typeof obj.disabled === 'string') &&
     (obj.updateMethod === undefined || typeof obj.updateMethod === 'string') &&
     (obj.maxVersions === undefined || typeof obj.maxVersions === 'number') &&
     (obj.minBackgroundDuration === undefined || typeof obj.minBackgroundDuration === 'number') &&


### PR DESCRIPTION
The `debug` preference has been unavailable since PR #142 and was replaced with the `disabled` preference.